### PR TITLE
make sure to land tello when ctx manager exits

### DIFF
--- a/examples/test-rc-control.py
+++ b/examples/test-rc-control.py
@@ -1,15 +1,14 @@
 from DroneBlocksTelloSimulator.DroneBlocksSimulatorContextManager import DroneBlocksSimulatorContextManager
-
+import time
 if __name__ == '__main__':
     sim_key = '4cca2720-5b26-4e90-bcdd-7662950960b4'
     # sim_key = None
     distance = 40
     with DroneBlocksSimulatorContextManager(simulator_key=sim_key) as drone:
         drone.takeoff()
-        drone.fly_forward(distance, 'in')
-        drone.fly_left(distance, 'in')
-        drone.fly_backward(distance, 'in')
-        drone.fly_right(distance, 'in')
+        drone.send_rc_control(0,0,50, 0)
+        time.sleep(3)
+        drone.send_rc_control(0,0,0,0)
         drone.land()
 
 

--- a/src/DroneBlocksTelloSimulator/DroneBlocksSimulatorContextManager.py
+++ b/src/DroneBlocksTelloSimulator/DroneBlocksSimulatorContextManager.py
@@ -45,4 +45,9 @@ class DroneBlocksSimulatorContextManager():
         # land and gracefully stop the Tello
         if self.simulator_key is None:
             self.db_tello.end()
+        else:
+            # we are running in the simulator, and when we leave
+            # the 'with' block be sure to land
+            self.db_tello.land()
+
 


### PR DESCRIPTION
Make sure to call 'land' when running in the simulator when the ctx manager with block exists.  If we dont, then it is possible the tello will hang and the ctx manager makes sure to land a real tello.  This change makes the behavior consistent